### PR TITLE
Remove unnecessary whitespace change

### DIFF
--- a/v5.x/uksm-5.6.patch
+++ b/v5.x/uksm-5.6.patch
@@ -77,14 +77,6 @@ index db17be51b112..0ce4c6303f53 100644
  
  #include <linux/uaccess.h>
  #include <asm/mmu_context.h>
-@@ -1387,6 +1388,7 @@ void setup_new_exec(struct linux_binprm * bprm)
- 	/* An exec changes our domain. We are no longer part of the thread
- 	   group */
- 	current->self_exec_id++;
-+
- 	flush_signal_handlers(current, 0);
- }
- EXPORT_SYMBOL(setup_new_exec);
 diff --git a/fs/proc/meminfo.c b/fs/proc/meminfo.c
 index 8c1f1bb1a5ce..62e28cf10bbf 100644
 --- a/fs/proc/meminfo.c


### PR DESCRIPTION
This whitespace change isn't required, and breaks the patch applying to the linux-ck kernel for me, so just remove the unnecessary diff.

No stress if you don't want to apply this :-) (I've just done it locally so not a stress :-) )