### PR TITLE
Fix warning: this statement may fall through [-Wimplicit-fallthrough=]

### DIFF
--- a/v5.x/uksm-5.16.patch
+++ b/v5.x/uksm-5.16.patch
@@ -6139,7 +6139,7 @@ index 0000000..bd9038a
 +		while ((stable_node = uksm_check_stable_tree(mn->start_pfn,
 +					mn->start_pfn + mn->nr_pages)) != NULL)
 +			remove_node_from_stable_tree(stable_node, 1, 1);
-+		/* fallthrough */
++		fallthrough;
 +
 +	case MEM_CANCEL_OFFLINE:
 +		mutex_unlock(&uksm_thread_mutex);

--- a/v5.x/uksm-5.17.patch
+++ b/v5.x/uksm-5.17.patch
@@ -6125,7 +6125,7 @@ index 000000000..e06cc0e39
 +		while ((stable_node = uksm_check_stable_tree(mn->start_pfn,
 +					mn->start_pfn + mn->nr_pages)) != NULL)
 +			remove_node_from_stable_tree(stable_node, 1, 1);
-+		/* fallthrough */
++		fallthrough;
 +
 +	case MEM_CANCEL_OFFLINE:
 +		mutex_unlock(&uksm_thread_mutex);


### PR DESCRIPTION
In a previous pull request I forgot to fix the following warning

```
CC mm/uksm.o
mm/uksm.c: In function 'uksm_memory_callback':
mm/uksm.c:4835:72: warning: this statement may fall through [-Wimplicit-fallthrough=]
 4835 | mn->start_pfn + mn->nr_pages)) != NULL)
mm/uksm.c:4839:9: note: here
 4839 | case MEM_CANCEL_OFFLINE:
      | ^~~~
```

A simple change was enough to eliminate the problem.

```
 CC [M] fs/nls/nls_koi8-ru.o
  CC [M] fs/nls/nls_utf8.o
  CC mm/uksm.o
  CC [M] fs/nls/mac-celtic.o
  CC arch/x86/kernel/cpu/sgx/ioctl.o
  CC kernel/time/hrtimer.o
  CC [M] fs/nls/mac-centeuro.o
  CC [M] fs/nls/mac-croatian.o
  CC [M] fs/nls/mac-cyrillic.o
  CC arch/x86/kernel/cpu/sgx/main.o
  CC [M] fs/nls/mac-gaelic.o
  CC kernel/time/timekeeping.o
  CC [M] fs/nls/mac-greek.o
  CC [M] fs/nls/mac-iceland.o
  CC arch/x86/kernel/cpu/sgx/virt.o
  CC [M] fs/nls/mac-inuit.o
  CC [M] fs/nls/mac-romanian
```
Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>